### PR TITLE
[nit] Add units to zField

### DIFF
--- a/sphinx_parser/input.py
+++ b/sphinx_parser/input.py
@@ -400,7 +400,7 @@ def _sphinx__PAWHamiltonian(
     nExcessElectrons: Optional[int] = None,
     spinPolarized: Optional[bool] = None,
     dipoleCorrection: Optional[bool] = None,
-    zField: u(Optional[float], units="eV/bohr") = None,
+    zField: u(Optional[float], units="hartree/bohr") = None,
     vExt: Optional[dict] = None,
     xcMesh: Optional[dict] = None,
     vdwCorrection: Optional[dict] = None,
@@ -417,7 +417,7 @@ def _sphinx__PAWHamiltonian(
         nExcessElectrons (int): The number of excess electrons to include in the calculation. (Optional)
         spinPolarized (bool): Whether to perform a spin-polarized calculation. (Optional)
         dipoleCorrection (bool): Use the dipole correction for slab systems. The in-plane lattice must be perpendicular to the z-axis, and the third basis vector must be aligned with the z-axis. For charged calculation, this requests the generalized dipole correction, which may need some care for initializing the charge (see charged in the initialGuess group). (Optional)
-        zField (float): Use an additional electric field along z when using the dipole correction. Units: eV/bohr. (Optional)
+        zField (float): Use an additional electric field along z when using the dipole correction. Units: hartree/bohr. (Optional)
         vExt (dict): External potential. (Optional)
         xcMesh (dict): Mesh for the exchange-correlation potential. (Optional)
         vdwCorrection (dict): Van der Waals correction. (Optional)

--- a/sphinx_parser/input.py
+++ b/sphinx_parser/input.py
@@ -400,7 +400,7 @@ def _sphinx__PAWHamiltonian(
     nExcessElectrons: Optional[int] = None,
     spinPolarized: Optional[bool] = None,
     dipoleCorrection: Optional[bool] = None,
-    zField: Optional[float] = None,
+    zField: u(Optional[float], units="eV/bohr") = None,
     vExt: Optional[dict] = None,
     xcMesh: Optional[dict] = None,
     vdwCorrection: Optional[dict] = None,
@@ -416,8 +416,8 @@ def _sphinx__PAWHamiltonian(
         nEmptyStates (int): The number of empty states to include in the calculation. (Optional)
         nExcessElectrons (int): The number of excess electrons to include in the calculation. (Optional)
         spinPolarized (bool): Whether to perform a spin-polarized calculation. (Optional)
-        dipoleCorrection (bool): Use the dipole correction for slab systems. The in-plane lattice must be perpendicular to the z- axis, and the third basis vector must be aligned with the z-axis. For charged calculation, this requests the generalized dipole correction, which may need some care for initializing the charge (see charged in the initialGuess group). (Optional)
-        zField (float): Use an additional electric field along z when using the dipole correction (eV/bohr). (Optional)
+        dipoleCorrection (bool): Use the dipole correction for slab systems. The in-plane lattice must be perpendicular to the z-axis, and the third basis vector must be aligned with the z-axis. For charged calculation, this requests the generalized dipole correction, which may need some care for initializing the charge (see charged in the initialGuess group). (Optional)
+        zField (float): Use an additional electric field along z when using the dipole correction. Units: eV/bohr. (Optional)
         vExt (dict): External potential. (Optional)
         xcMesh (dict): Mesh for the exchange-correlation potential. (Optional)
         vdwCorrection (dict): Van der Waals correction. (Optional)

--- a/sphinx_parser/src/input_data.yml
+++ b/sphinx_parser/src/input_data.yml
@@ -225,7 +225,7 @@ sphinx:
       description: Use the dipole correction for slab systems. The in-plane lattice must be perpendicular to the z-axis, and the third basis vector must be aligned with the z-axis. For charged calculation, this requests the generalized dipole correction, which may need some care for initializing the charge (see charged in the initialGuess group).
     zField:
       data_type: float
-      units: eV/bohr
+      units: hartree/bohr
       required: false
       description: Use an additional electric field along z when using the dipole correction
     vExt:

--- a/sphinx_parser/src/input_data.yml
+++ b/sphinx_parser/src/input_data.yml
@@ -222,11 +222,12 @@ sphinx:
     dipoleCorrection:
       data_type: bool
       required: false
-      description: Use the dipole correction for slab systems. The in-plane lattice must be perpendicular to the z- axis, and the third basis vector must be aligned with the z-axis. For charged calculation, this requests the generalized dipole correction, which may need some care for initializing the charge (see charged in the initialGuess group).
+      description: Use the dipole correction for slab systems. The in-plane lattice must be perpendicular to the z-axis, and the third basis vector must be aligned with the z-axis. For charged calculation, this requests the generalized dipole correction, which may need some care for initializing the charge (see charged in the initialGuess group).
     zField:
       data_type: float
+      units: eV/bohr
       required: false
-      description: Use an additional electric field along z when using the dipole correction (eV/bohr)
+      description: Use an additional electric field along z when using the dipole correction
     vExt:
       description: External potential
       file:


### PR DESCRIPTION
This pull request makes a minor documentation update to the `zField` parameter in the `input_data.yml` file for the Sphinx parser. The update clarifies the units for `zField` and improves the parameter description.

- Documentation improvements:
  * Added the `units: eV/bohr` field and clarified the `description` for the `zField` parameter in `input_data.yml` to specify the units and remove redundancy.