### PR TITLE
Move location of func_in_func and convert numpy to python native object

### DIFF
--- a/sphinx_parser/input.py
+++ b/sphinx_parser/input.py
@@ -1,19 +1,9 @@
-from functools import wraps
 from typing import Annotated, Optional
 
 import numpy as np
 from semantikon.converter import units
 
-from sphinx_parser.toolkit import fill_values
-
-
-def _func_in_func(parentfunc):
-    @wraps(parentfunc)
-    def register(childfunc):
-        parentfunc.__dict__[childfunc.__name__.split("__")[-1]] = childfunc
-        return parentfunc
-
-    return register
+from sphinx_parser.toolkit import fill_values, _func_in_func
 
 
 @units

--- a/sphinx_parser/input.py
+++ b/sphinx_parser/input.py
@@ -3,7 +3,7 @@ from typing import Annotated, Optional
 import numpy as np
 from semantikon.converter import units
 
-from sphinx_parser.toolkit import fill_values, _func_in_func
+from sphinx_parser.toolkit import _func_in_func, fill_values
 
 
 @units

--- a/sphinx_parser/src/generator.py
+++ b/sphinx_parser/src/generator.py
@@ -240,7 +240,7 @@ def _get_file_content(yml_file_name: str = "input_data.yml") -> str:
         "import numpy as np",
         "from semantikon.converter import units",
         "",
-        "from sphinx_parser.toolkit import fill_values, _func_in_func",
+        "from sphinx_parser.toolkit import _func_in_func, fill_values",
         "",
         "",
     ]

--- a/sphinx_parser/src/generator.py
+++ b/sphinx_parser/src/generator.py
@@ -235,21 +235,14 @@ def _get_file_content(yml_file_name: str = "input_data.yml") -> str:
     all_data = _replace_alias(all_data)
     file_content = _get_class(all_data)
     imports = [
-        "from functools import wraps",
         "from typing import Annotated, Optional",
         "",
         "import numpy as np",
         "from semantikon.converter import units",
         "",
-        "from sphinx_parser.toolkit import fill_values",
+        "from sphinx_parser.toolkit import fill_values, _func_in_func",
         "",
         "",
-        "def _func_in_func(parentfunc):",
-        "    @wraps(parentfunc)",
-        "    def register(childfunc):",
-        "        parentfunc.__dict__[childfunc.__name__.split('__')[-1]] = childfunc",
-        "        return parentfunc",
-        "    return register",
     ]
     file_content = "\n".join(imports) + "\n\n\n" + file_content
     file_content = format_str(file_content, mode=FileMode())
@@ -258,7 +251,7 @@ def _get_file_content(yml_file_name: str = "input_data.yml") -> str:
 
 def export_class(yml_file_name: str = "input_data.yml", py_file_name: str = "input.py"):
     file_content = _get_file_content(yml_file_name)
-    with open(os.path.join(os.path.dirname(__file__), "..", py_file_name), "w") as f:
+    with open(os.path.join(os.path.dirname(__file__), r"..", py_file_name), "w") as f:
         f.write(file_content)
 
 

--- a/sphinx_parser/toolkit.py
+++ b/sphinx_parser/toolkit.py
@@ -43,6 +43,8 @@ def to_sphinx(obj: dict, indent: int = 0, include_format: bool = True) -> str:
 
 
 def append_item(group: dict, key: str, value: Any, n_max: int = int(1e8)) -> dict:
+    if isinstance(value, np.generic):
+        value = value.item()
     if key not in group:
         group[key] = value
         return group

--- a/sphinx_parser/toolkit.py
+++ b/sphinx_parser/toolkit.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import Any
 
 import numpy as np
@@ -71,3 +72,12 @@ def fill_values(wrap_string: bool = True, **kwargs) -> dict:
 
 def _wrap_string(string: str) -> str:
     return f'"{string}"'
+
+
+def _func_in_func(parentfunc):
+    @wraps(parentfunc)
+    def register(childfunc):
+        parentfunc.__dict__[childfunc.__name__.split("__")[-1]] = childfunc
+        return parentfunc
+
+    return register


### PR DESCRIPTION
This pull request refactors the handling and import of the `_func_in_func` utility, improves value handling in `append_item`, and makes a minor path string update. The most notable changes are the relocation of `_func_in_func` to a shared toolkit, ensuring consistent imports in generated files, and improved type handling for NumPy values.

**Refactoring and utility consolidation:**

* Moved the `_func_in_func` function from `sphinx_parser/input.py` into `sphinx_parser/toolkit.py` to centralize utility functions. All relevant imports and code generation templates have been updated to import `_func_in_func` from the toolkit, ensuring consistency and reducing code duplication. [[1]](diffhunk://#diff-39388d7e79afa7d73c0dc2f9e268a495f77861330dfc5a90245bf3a70276d4ecL1-R6) [[2]](diffhunk://#diff-58af7b9313509d70327f0bb28736142005c0e55b8ea01aac8783c27bf6aee2e9L238-L252) [[3]](diffhunk://#diff-1d5ef7d05f7e613a1dcae5a28169df9638417f446cf6088c55c4dd15e47f5fb2R1) [[4]](diffhunk://#diff-1d5ef7d05f7e613a1dcae5a28169df9638417f446cf6088c55c4dd15e47f5fb2R77-R85)

**Type handling improvements:**

* Updated the `append_item` function in `sphinx_parser/toolkit.py` to automatically convert NumPy scalar values to native Python types using `.item()`, improving compatibility and preventing type issues when adding values to dictionaries.

**Code generation and path handling:**

* Modified the file path string in `export_class` in `sphinx_parser/src/generator.py` to use a raw string literal for the parent directory, which can help avoid issues with escape sequences on some platforms.