### PR TITLE
Show boolean explicitly

### DIFF
--- a/sphinx_parser/toolkit.py
+++ b/sphinx_parser/toolkit.py
@@ -61,7 +61,7 @@ def fill_values(wrap_string: bool = True, **kwargs) -> dict:
     for k, v in kwargs.items():
         while k.endswith("_"):
             k = k[:-1]
-        if v is not None and v is not False:
+        if v is not None:
             if isinstance(v, list) and len(v) > 0 and isinstance(v[0], dict):
                 for i, vv in enumerate(v):
                     group = append_item(group, k, vv)

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -52,7 +52,7 @@ class TestInput(unittest.TestCase):
     def test_boolean(self):
         self.assertEqual(
             to_sphinx(fill_values(hello=True, world=[{"a": True}, {"a": False}])),
-            "hello = true;\nworld {\n\ta = true;\n}\nworld {\n\ta = false;\n}\n"
+            "hello = true;\nworld {\n\ta = true;\n}\nworld {\n\ta = false;\n}\n",
         )
 
 

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -49,6 +49,12 @@ class TestInput(unittest.TestCase):
             {"dEnergy": 3.6749322175664394e-09, "maxSteps": 10, "blockCCG": {}},
         )
 
+    def test_boolean(self):
+        self.assertEqual(
+            to_sphinx({"hello": True, "world": False}),
+            "hello = true;\nworld = false;\n"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -3,7 +3,7 @@ import unittest
 from pint import UnitRegistry
 
 from sphinx_parser.input import sphinx
-from sphinx_parser.toolkit import to_sphinx
+from sphinx_parser.toolkit import fill_values, to_sphinx
 
 
 class TestInput(unittest.TestCase):
@@ -51,8 +51,8 @@ class TestInput(unittest.TestCase):
 
     def test_boolean(self):
         self.assertEqual(
-            to_sphinx({"hello": True, "world": False}),
-            "hello = true;\nworld = false;\n"
+            to_sphinx(fill_values(hello=True, world=[{"a": True}, {"a": False}])),
+            "hello = true;\nworld {\n\ta = true;\n}\nworld {\n\ta = false;\n}\n"
         )
 
 


### PR DESCRIPTION
This pull request introduces a minor change to the `fill_values` function in `sphinx_parser/toolkit.py` to ensure that boolean values set to `False` are no longer skipped, and adds a corresponding unit test to verify correct handling of boolean values in the output.

Testing improvements:

* Added a new unit test `test_boolean` in `tests/unit/test_input.py` to verify that both `True` and `False` boolean values are correctly serialized by `to_sphinx` after processing with `fill_values`.
* Updated the test imports in `tests/unit/test_input.py` to include `fill_values` for direct testing.

Bug fix:

* Modified the conditional in `fill_values` (in `sphinx_parser/toolkit.py`) so that values set to `False` are no longer skipped, ensuring all boolean values are preserved in the output.