### PR TITLE
Add transPath to input

### DIFF
--- a/sphinx_parser/input.py
+++ b/sphinx_parser/input.py
@@ -2384,7 +2384,7 @@ def _sphinx__main__ricTS(
         scheme (int): Hesse update scheme (0=Murtagh-Sargent, 1=Powell symmetric Broyden, 2=Borrell, 3=Farkas-Schlegel, see [11], Eqs. 6-10). Default: 1. (Optional)
         driftFilter (bool): Drift filter. (Optional)
         bornOppenheimer (dict): The bornOppenheimer group defines the electronic loop within a geometry optimization. It contains one or more of the electronic loop groups. If more than one minimizer is used, the complete electronic loop sequence is executed at each ionic step. (Optional)
-        transPath (dict): The transPath group defines the initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x, y, z displacements for each atom (3 values for atomId or 3 values for each index in atomIds). (Optional)
+        transPath (dict): The transPath group defines initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x, y, z displacements for each atom (3 values for atomId or 3 values for each index in atomIds). (Optional)
         wrap_string (bool): Whether to wrap string values in apostrophes.
     """
     return fill_values(

--- a/sphinx_parser/input.py
+++ b/sphinx_parser/input.py
@@ -2623,7 +2623,7 @@ def _sphinx__main__ricTS__transPath(
     wrap_string: bool = True,
 ):
     """
-    The transPath group denes initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x,y,zdisplacements for each atom (3 values for atomId or 3 values for each index in atomIds).
+    The transPath group defines initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x, y, z displacements for each atom (3 values for atomId or 3 values for each index in atomIds).
 
     Args:
         dir_ (list): List of x,y,z displacements for each atom (3 values for atomId or 3 values for each index in atomIds).

--- a/sphinx_parser/input.py
+++ b/sphinx_parser/input.py
@@ -2384,7 +2384,7 @@ def _sphinx__main__ricTS(
         scheme (int): Hesse update scheme (0=Murtagh-Sargent, 1=Powell symmetric Broyden, 2=Borrell, 3=Farkas-Schlegel, see [11], Eqs. 6-10). Default: 1. (Optional)
         driftFilter (bool): Drift filter. (Optional)
         bornOppenheimer (dict): The bornOppenheimer group defines the electronic loop within a geometry optimization. It contains one or more of the electronic loop groups. If more than one minimizer is used, the complete electronic loop sequence is executed at each ionic step. (Optional)
-        transPath (dict): The transPath group denes initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x,y,zdisplacements for each atom (3 values for atomId or 3 values for each index in atomIds). (Optional)
+        transPath (dict): The transPath group defines the initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x, y, z displacements for each atom (3 values for atomId or 3 values for each index in atomIds). (Optional)
         wrap_string (bool): Whether to wrap string values in apostrophes.
     """
     return fill_values(

--- a/sphinx_parser/input.py
+++ b/sphinx_parser/input.py
@@ -2365,6 +2365,7 @@ def _sphinx__main__ricTS(
     scheme: Optional[int] = None,
     driftFilter: Optional[bool] = None,
     bornOppenheimer: Optional[dict] = None,
+    transPath: Optional[dict] = None,
     wrap_string: bool = True,
 ):
     """
@@ -2383,6 +2384,7 @@ def _sphinx__main__ricTS(
         scheme (int): Hesse update scheme (0=Murtagh-Sargent, 1=Powell symmetric Broyden, 2=Borrell, 3=Farkas-Schlegel, see [11], Eqs. 6-10). Default: 1. (Optional)
         driftFilter (bool): Drift filter. (Optional)
         bornOppenheimer (dict): The bornOppenheimer group defines the electronic loop within a geometry optimization. It contains one or more of the electronic loop groups. If more than one minimizer is used, the complete electronic loop sequence is executed at each ionic step. (Optional)
+        transPath (dict): The transPath group denes initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x,y,zdisplacements for each atom (3 values for atomId or 3 values for each index in atomIds). (Optional)
         wrap_string (bool): Whether to wrap string values in apostrophes.
     """
     return fill_values(
@@ -2398,6 +2400,7 @@ def _sphinx__main__ricTS(
         scheme=scheme,
         driftFilter=driftFilter,
         bornOppenheimer=bornOppenheimer,
+        transPath=transPath,
         wrap_string=wrap_string,
     )
 
@@ -2607,6 +2610,31 @@ def _sphinx__main__ricTS__bornOppenheimer__scfDiag__preconditioner(
         scaling=scaling,
         spinScaling=spinScaling,
         dielecConstant=dielecConstant,
+        wrap_string=wrap_string,
+    )
+
+
+@_func_in_func(sphinx.main.ricTS)
+@units
+def _sphinx__main__ricTS__transPath(
+    dir_: list,
+    atomId: Optional[int] = None,
+    atomIds: Optional[list] = None,
+    wrap_string: bool = True,
+):
+    """
+    The transPath group denes initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x,y,zdisplacements for each atom (3 values for atomId or 3 values for each index in atomIds).
+
+    Args:
+        dir_ (list): List of x,y,z displacements for each atom (3 values for atomId or 3 values for each index in atomIds).
+        atomId (int): Atom id (starting from 1) for which to set the transition direction. (Optional)
+        atomIds (list): List of atom ids (starting from 1) for which to set the transition direction. (Optional)
+        wrap_string (bool): Whether to wrap string values in apostrophes.
+    """
+    return fill_values(
+        dir_=dir_,
+        atomId=atomId,
+        atomIds=atomIds,
         wrap_string=wrap_string,
     )
 

--- a/sphinx_parser/src/input_data.yml
+++ b/sphinx_parser/src/input_data.yml
@@ -1033,6 +1033,20 @@ sphinx:
         description: Drift filter
       bornOppenheimer:
         alias: sphinx.main.QN.bornOppenheimer
+      transPath:
+        description: The transPath group denes initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x,y,zdisplacements for each atom (3 values for atomId or 3 values for each index in atomIds).
+        atomId:
+          data_type: int
+          required: false
+          description: Atom id (starting from 1) for which to set the transition direction.
+        atomIds:
+          data_type: list
+          required: false
+          description: List of atom ids (starting from 1) for which to set the transition direction.
+        dir:
+          data_type: list
+          required: true
+          description: List of x,y,z displacements for each atom (3 values for atomId or 3 values for each index in atomIds).
     evalForces:
       description: The evalForces group is used to calculate forces and write them to a file in sx-format. This is useful for single-point calculations without a structure optimization. It should be used after an electronic loop.
       file:

--- a/sphinx_parser/src/input_data.yml
+++ b/sphinx_parser/src/input_data.yml
@@ -1034,7 +1034,7 @@ sphinx:
       bornOppenheimer:
         alias: sphinx.main.QN.bornOppenheimer
       transPath:
-        description: The transPath group denes initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x,y,zdisplacements for each atom (3 values for atomId or 3 values for each index in atomIds).
+        description: The transPath group defines initial guess for the atomic displacement pattern along the negative curvature (transition direction). Either atomId or atomIds must be set. dir contains the x, y, z displacements for each atom (3 values for atomId or 3 values for each index in atomIds).
         atomId:
           data_type: int
           required: false


### PR DESCRIPTION
This pull request adds support for the `transPath` group to the `ricTS` section in the Sphinx input parser. The `transPath` group allows users to specify an initial guess for the atomic displacement pattern along the transition direction, which is important for transition state searches. The changes include updates to both the Python parser logic and the YAML schema.

New feature: `transPath` support in `ricTS`:

* Added an optional `transPath` parameter to the `_sphinx__main__ricTS` function, updated its docstring, and ensured it is passed to the underlying value filler. (`sphinx_parser/input.py`) [[1]](diffhunk://#diff-39388d7e79afa7d73c0dc2f9e268a495f77861330dfc5a90245bf3a70276d4ecR2368) [[2]](diffhunk://#diff-39388d7e79afa7d73c0dc2f9e268a495f77861330dfc5a90245bf3a70276d4ecR2387) [[3]](diffhunk://#diff-39388d7e79afa7d73c0dc2f9e268a495f77861330dfc5a90245bf3a70276d4ecR2403)
* Implemented the `_sphinx__main__ricTS__transPath` helper function to handle the `transPath` group, including its arguments (`dir_`, `atomId`, `atomIds`) and documentation. (`sphinx_parser/input.py`)

Schema update:

* Added the `transPath` group to the `sphinx.main.ricTS` section in the YAML schema, with fields for `atomId`, `atomIds`, and `dir`, along with descriptions and data types. (`sphinx_parser/src/input_data.yml`)